### PR TITLE
DM-47638: Fix the inPosition timeout issues

### DIFF
--- a/doc/news/DM-47638.bugfix.rst
+++ b/doc/news/DM-47638.bugfix.rst
@@ -1,0 +1,1 @@
+Modified the inPosition calculation for mask rotation to deal with 0 and 360. Also increased the timeout for the mask change.

--- a/python/lsst/ts/cbp/component.py
+++ b/python/lsst/ts/cbp/component.py
@@ -24,8 +24,10 @@ __all__ = ["CBPComponent"]
 
 import asyncio
 import logging
+import math
 import types
 
+import numpy as np
 from lsst.ts import tcpip
 
 
@@ -172,8 +174,11 @@ class CBPComponent:
             elevation=abs(self.elevation - self.target.elevation)
             < self.error_tolerance,
             mask=self.mask == self.target.mask,
-            mask_rotation=abs(self.mask_rotation - self.target.mask_rotation)
-            < self.error_tolerance * 5,
+            mask_rotation=1
+            - math.cos(
+                np.deg2rad(self.mask_rotation) - np.deg2rad(self.target.mask_rotation)
+            )
+            < 1e-5,
             focus=abs(self.focus - self.target.focus) < self.focus_crosstalk,
         )
         return did_change

--- a/python/lsst/ts/cbp/component.py
+++ b/python/lsst/ts/cbp/component.py
@@ -87,6 +87,7 @@ class CBPComponent:
         # 9999 divided by 186413 is approximately 0.053
         # So the value is set to 0.1
         self.error_tolerance = 0.1
+        self.rotation_tolerance = 1e-5
         self.focus_crosstalk = 0.5
         self.terminator = "\r\n"
         self.client = None
@@ -178,7 +179,7 @@ class CBPComponent:
             - math.cos(
                 np.deg2rad(self.mask_rotation) - np.deg2rad(self.target.mask_rotation)
             )
-            < 1e-5,
+            < self.rotation_tolerance,
             focus=abs(self.focus - self.target.focus) < self.focus_crosstalk,
         )
         return did_change

--- a/python/lsst/ts/cbp/component.py
+++ b/python/lsst/ts/cbp/component.py
@@ -27,7 +27,6 @@ import logging
 import math
 import types
 
-import numpy as np
 from lsst.ts import tcpip
 
 
@@ -177,7 +176,8 @@ class CBPComponent:
             mask=self.mask == self.target.mask,
             mask_rotation=1
             - math.cos(
-                np.deg2rad(self.mask_rotation) - np.deg2rad(self.target.mask_rotation)
+                math.radians(self.mask_rotation)
+                - math.radians(self.target.mask_rotation)
             )
             < self.rotation_tolerance,
             focus=abs(self.focus - self.target.focus) < self.focus_crosstalk,

--- a/python/lsst/ts/cbp/config_schema.py
+++ b/python/lsst/ts/cbp/config_schema.py
@@ -28,7 +28,7 @@ CONFIG_SCHEMA = yaml.safe_load(
     """
 $schema: http://json-schema.org/draft-07/schema#
 $id: https://github.com/lsst-ts/ts_CBP/blob/master/schema/CBP.yaml
-title: CBP v1
+title: CBP v2
 description: Schema for CBP configuration files
 type: object
 properties:

--- a/python/lsst/ts/cbp/config_schema.py
+++ b/python/lsst/ts/cbp/config_schema.py
@@ -100,15 +100,7 @@ properties:
         type: number
         description: Rotation of mask (degree)
         default: 150
-  encoder_tolerance:
-    description: Encoder error tolerance for in_position event
-    type: number
-    default: 0.1
-  focus_crosstalk:
-    description: Focus encoder crosstalk when moving tolerance
-    type: number
-    default: 0.4
-required: [address, port, mask1, mask2, mask3, mask4, mask5, encoder_tolerance, focus_crosstalk]
+required: [address, port, mask1, mask2, mask3, mask4, mask5]
 additionalProperties: false
 """
 )

--- a/python/lsst/ts/cbp/csc.py
+++ b/python/lsst/ts/cbp/csc.py
@@ -88,7 +88,7 @@ class CBPCSC(salobj.ConfigurableCsc):
         self.telemetry_task = utils.make_done_future()
         self.telemetry_interval = 0.5
         self.in_position_timeout = 20
-        self.mask_timeout = 90
+        self.mask_timeout = 90  # 20 sec per mask.
         self.log.info("CBP CSC initialized")
 
     async def do_move(self, data):

--- a/python/lsst/ts/cbp/csc.py
+++ b/python/lsst/ts/cbp/csc.py
@@ -88,6 +88,7 @@ class CBPCSC(salobj.ConfigurableCsc):
         self.telemetry_task = utils.make_done_future()
         self.telemetry_interval = 0.5
         self.in_position_timeout = 20
+        self.mask_timeout = 90
         self.log.info("CBP CSC initialized")
 
     async def do_move(self, data):
@@ -178,7 +179,7 @@ class CBPCSC(salobj.ConfigurableCsc):
         """
         self.assert_enabled("changeMask")
         await self.component.set_mask(data.mask)
-        await asyncio.wait_for(self.in_position(), self.in_position_timeout)
+        await asyncio.wait_for(self.in_position(), self.mask_timeout)
 
     async def do_changeMaskRotation(self, data):
         """Changes the mask rotation variable and moves the
@@ -191,7 +192,7 @@ class CBPCSC(salobj.ConfigurableCsc):
         """
         self.assert_enabled("changeMaskRotation")
         await self.component.set_mask_rotation(data.mask_rotation)
-        await asyncio.wait_for(self.in_position(), self.in_position_timeout)
+        await asyncio.wait_for(self.in_position(), self.mask_timeout)
 
     async def handle_summary_state(self):
         """Handle the summary state."""

--- a/python/lsst/ts/cbp/csc.py
+++ b/python/lsst/ts/cbp/csc.py
@@ -178,7 +178,7 @@ class CBPCSC(salobj.ConfigurableCsc):
 
         """
         self.assert_enabled("changeMask")
-        await self.component.set_mask(data.mask)
+        await self.component.set_mask(str(data.mask))
         await asyncio.wait_for(self.in_position(), self.mask_timeout)
 
     async def do_changeMaskRotation(self, data):
@@ -221,6 +221,7 @@ class CBPCSC(salobj.ConfigurableCsc):
         ----------
         config : `types.SimpleNamespace`
         """
+        self.log.debug("We do configure indeed")
         self.component.configure(config)
 
     @staticmethod

--- a/python/lsst/ts/cbp/mock_server.py
+++ b/python/lsst/ts/cbp/mock_server.py
@@ -106,7 +106,6 @@ class MockServer(tcpip.OneClientReadLoopServer):
         self.encoders = Encoders()
         self.park = False
         self.auto_park = False
-        # self.masks_rotation = {1: 0, 2: 0, 3: 0, 4: 0, 5: 0}
         self.movement_reply = ":"
         self.commands = (
             (re.compile(r"az=\?"), self.do_azimuth),

--- a/python/lsst/ts/cbp/mock_server.py
+++ b/python/lsst/ts/cbp/mock_server.py
@@ -106,7 +106,7 @@ class MockServer(tcpip.OneClientReadLoopServer):
         self.encoders = Encoders()
         self.park = False
         self.auto_park = False
-        self.masks_rotation = {1: 0, 2: 0, 3: 0, 4: 0, 5: 0}
+        # self.masks_rotation = {1: 0, 2: 0, 3: 0, 4: 0, 5: 0}
         self.movement_reply = ":"
         self.commands = (
             (re.compile(r"az=\?"), self.do_azimuth),
@@ -245,6 +245,7 @@ class MockServer(tcpip.OneClientReadLoopServer):
         """
         constrained_value = min(max(0, value), 360)
         self.log.info(f"constrained_value: {constrained_value}")
+        self.log.debug(f"from actuator {actuator.set_position(constrained_value)}")
         actuator.set_position(constrained_value)
 
     async def do_azimuth(self):
@@ -323,6 +324,7 @@ class MockServer(tcpip.OneClientReadLoopServer):
         -------
         str
         """
+        self.log.debug(f"mask_select: {self.encoders.mask_select.position()}")
         return f"{self.encoders.mask_select.position()}"
 
     async def do_new_mask(self, mask):
@@ -348,6 +350,7 @@ class MockServer(tcpip.OneClientReadLoopServer):
         -------
         str
         """
+        self.log.debug(f"do_rotation {self.encoders.mask_rotate.position()}")
         return f"{self.encoders.mask_rotate.position()}"
 
     async def do_new_rotation(self, rotation):

--- a/tests/data/config/_init.yaml
+++ b/tests/data/config/_init.yaml
@@ -15,5 +15,3 @@ mask4:
 mask5:
     name: mask 5
     rotation: 150
-encoder_tolerance: 0.1
-focus_crosstalk: 0.4


### PR DESCRIPTION
I think that the error_allowance is appropriate and shouldn't be problematic with the motion of the CBP. I left that alone. The major changes needed are with the timeout of the mask, the mask rotation values, and the publishing of the mask within mask rotation.